### PR TITLE
Added 2nd Part of the Screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("com.google.firebase:firebase-crashlytics-buildtools:2.9.9")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
@@ -84,4 +85,6 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
     implementation("androidx.activity:activity-compose:1.7.2")
     implementation("androidx.compose.runtime:runtime-livedata:1.4.3")
+
+    implementation("io.coil-kt:coil-compose:1.3.2")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/unifyassignment/data/models/PaymentGateway.kt
+++ b/app/src/main/java/com/example/unifyassignment/data/models/PaymentGateway.kt
@@ -1,0 +1,7 @@
+package com.example.unifyassignment.data.models
+
+data class PaymentGateway(
+    val name: String,
+    val details: String,
+    val imageUrl: String
+)

--- a/app/src/main/java/com/example/unifyassignment/data/repositories/MandateRepository.kt
+++ b/app/src/main/java/com/example/unifyassignment/data/repositories/MandateRepository.kt
@@ -1,7 +1,9 @@
 package com.example.unifyassignment.data.repositories
 
 import com.example.unifyassignment.data.models.Mandate
+import com.example.unifyassignment.data.models.PaymentGateway
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 
 class MandateRepository {
 
@@ -17,5 +19,20 @@ class MandateRepository {
             }
         """
         return Gson().fromJson(jsonData, Mandate::class.java)
+    }
+
+    fun fetchPaymentGateway(): List<PaymentGateway> {
+        val jsonData = """[
+            {"name": "Gateway1", "details": "Card Detail1", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/a.png"
+            },
+            {"name": "Gateway2", "details": "Card Detail2", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/m.png"
+            },
+            {"name": "Gateway3", "details": "Card Detail3", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/fp.png"
+            }
+            ]
+        """
+        val gson = Gson()
+        val type = object: TypeToken<List<PaymentGateway>>() {}.type
+        return gson.fromJson(jsonData, type)
     }
 }

--- a/app/src/main/java/com/example/unifyassignment/ui/composable/MandateScreen.kt
+++ b/app/src/main/java/com/example/unifyassignment/ui/composable/MandateScreen.kt
@@ -1,29 +1,34 @@
 package com.example.unifyassignment.ui.composable
 
-import androidx.compose.foundation.background
+import android.util.Log
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.CardColors
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material.Card
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
-import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -31,7 +36,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.rememberImagePainter
 import com.example.unifyassignment.data.models.Mandate
+import com.example.unifyassignment.data.models.PaymentGateway
 import com.example.unifyassignment.ui.viewmodels.MandateViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -39,10 +46,13 @@ import com.example.unifyassignment.ui.viewmodels.MandateViewModel
 fun MandateScreen(viewModel: MandateViewModel) {
 
     val mandate by viewModel.mandateLiveData.observeAsState()
+    val paymentGateway = viewModel.paymentLiveDate.observeAsState(initial = emptyList()).value
+    var selectedPaymentGateway by remember {
+        mutableStateOf<PaymentGateway?>(null) }
 
     Column(
         modifier = Modifier
-            .padding(horizontal = 10.dp)
+            .padding(horizontal = 10.dp, vertical = 10.dp)
             .fillMaxWidth()
             .verticalScroll(rememberScrollState())
     ) {
@@ -55,10 +65,21 @@ fun MandateScreen(viewModel: MandateViewModel) {
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth()) {
+            paymentGateway.forEach { gateway ->
+                paymentCardContent(paymentGateway = gateway) {
+                    Log.e("MandateScreen", "Cardclicked:  ${it.name}")
+                    selectedPaymentGateway = it
+                }
+            }
             }
         Spacer(modifier = Modifier.height(16.dp))
         ElevatedCard {
-            Modifier.fillMaxWidth().height(100.dp)
+            Modifier
+                .fillMaxWidth()
+            selectedPaymentGateway?.let {
+                payment -> Text(text = "${payment.name} - ${payment.details}")
+                Log.e("MandateScreen", "Cardclicked:  ${payment.name}")
+            }
         }
     }
 }
@@ -112,4 +133,27 @@ fun FirstCardContent(mandate: Mandate?) {
             )
         }
     }
+}
+
+@Composable
+fun paymentCardContent(
+    paymentGateway: PaymentGateway,
+    onClick: (PaymentGateway) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .clickable { onClick(paymentGateway) }
+            .padding(end = 8.dp)
+            .fillMaxWidth()
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Image(
+                painter = rememberImagePainter(data = paymentGateway.imageUrl),
+                contentDescription = paymentGateway.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/unifyassignment/ui/composable/TopBar.kt
+++ b/app/src/main/java/com/example/unifyassignment/ui/composable/TopBar.kt
@@ -3,6 +3,7 @@ package com.example.unifyassignment.ui.composable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowLeft
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -10,9 +11,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
@@ -20,6 +23,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun TopBar() {
     TopAppBar(
+        modifier = Modifier.shadow(10.dp),
         title = {
             Box(
                 modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/example/unifyassignment/ui/viewmodels/MandateViewModel.kt
+++ b/app/src/main/java/com/example/unifyassignment/ui/viewmodels/MandateViewModel.kt
@@ -1,13 +1,17 @@
 package com.example.unifyassignment.ui.viewmodels
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.unifyassignment.data.models.Mandate
+import com.example.unifyassignment.data.models.PaymentGateway
 import com.example.unifyassignment.data.repositories.MandateRepository
 
 class MandateViewModel(private val repository: MandateRepository) : ViewModel() {
 
     val mandateLiveData: MutableLiveData<Mandate> = MutableLiveData()
+    private val _paymentGateways = MutableLiveData<List<PaymentGateway>>(emptyList())
+    val paymentLiveDate: LiveData<List<PaymentGateway>> = _paymentGateways
 
     init {
         fetchData()
@@ -16,5 +20,8 @@ class MandateViewModel(private val repository: MandateRepository) : ViewModel() 
     private fun fetchData() {
         val mandate = repository.fetchMandateData()
         mandateLiveData.value = mandate
+
+        val payment = repository.fetchPaymentGateway()
+        _paymentGateways.value = payment
     }
 }


### PR DESCRIPTION
In the PR, the following changes have been added:

- A new json variable with all the details including payment detail, and image uri, which will be fetched in the composable screen.
- Added the required composable view in Mandate screen only to show the json data.
- For paymentGateway, added a new data class, and makes changes in viewmodel and repository class.
- Added shadow to the Top Bar.

TODO:
- Currently, the json is not being able to be fetched over the screen.
- Have added a redundant dependency, Will need to clean-up the code after completion.