### PR TITLE
Added Final UI and given final touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# Assignment1

--- a/app/src/main/java/com/example/unifyassignment/data/repositories/MandateRepository.kt
+++ b/app/src/main/java/com/example/unifyassignment/data/repositories/MandateRepository.kt
@@ -23,11 +23,11 @@ class MandateRepository {
 
     fun fetchPaymentGateway(): List<PaymentGateway> {
         val jsonData = """[
-            {"name": "Gateway1", "details": "Card Detail1", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/a.png"
+            {"name": "Airtel Payment Gateway", "details": "XXXX4213", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/a.png"
             },
-            {"name": "Gateway2", "details": "Card Detail2", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/m.png"
+            {"name": "MTN Payment Gateway", "details": "XXXX4213", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/m.png"
             },
-            {"name": "Gateway3", "details": "Card Detail3", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/fp.png"
+            {"name": "Flexi Pay Payment Gateway", "details": "XXXX4213", "imageUrl": "https://apptestsoko.s3.ap-south-1.amazonaws.com/assets/fp.png"
             }
             ]
         """

--- a/app/src/main/java/com/example/unifyassignment/ui/composable/MandateScreen.kt
+++ b/app/src/main/java/com/example/unifyassignment/ui/composable/MandateScreen.kt
@@ -1,6 +1,5 @@
 package com.example.unifyassignment.ui.composable
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -12,9 +11,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -28,7 +29,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -37,6 +40,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberImagePainter
+import com.example.unifyassignment.R
 import com.example.unifyassignment.data.models.Mandate
 import com.example.unifyassignment.data.models.PaymentGateway
 import com.example.unifyassignment.ui.viewmodels.MandateViewModel
@@ -56,10 +60,10 @@ fun MandateScreen(viewModel: MandateViewModel) {
             .fillMaxWidth()
             .verticalScroll(rememberScrollState())
     ) {
-        ElevatedCard(onClick = {/* TODO*/ }) {
+        ElevatedCard(onClick = {/* TODO*/ }, colors = CardDefaults.elevatedCardColors(Color.White)) {
             FirstCardContent(mandate)
         }
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(14.dp))
         Text(text = "Autopay Payment Options", style = TextStyle(fontWeight = FontWeight.ExtraBold, fontSize = 20.sp))
         Spacer(modifier = Modifier.height(16.dp))
         Row(
@@ -67,18 +71,43 @@ fun MandateScreen(viewModel: MandateViewModel) {
             modifier = Modifier.fillMaxWidth()) {
             paymentGateway.forEach { gateway ->
                 paymentCardContent(paymentGateway = gateway) {
-                    Log.e("MandateScreen", "Cardclicked:  ${it.name}")
                     selectedPaymentGateway = it
                 }
             }
             }
-        Spacer(modifier = Modifier.height(16.dp))
-        ElevatedCard {
-            Modifier
+        Spacer(modifier = Modifier.height(14.dp))
+        Text(text = "Paying Using", style = TextStyle(fontWeight = FontWeight.ExtraBold, fontSize = 10.sp))
+        Spacer(modifier = Modifier.height(12.dp))
+        ElevatedCard(
+            modifier = Modifier
                 .fillMaxWidth()
+                .padding(2.dp), shape = RectangleShape,
+            ){
             selectedPaymentGateway?.let {
-                payment -> Text(text = "${payment.name} - ${payment.details}")
-                Log.e("MandateScreen", "Cardclicked:  ${payment.name}")
+                payment ->
+                Row (horizontalArrangement = Arrangement.SpaceBetween){
+                    Image(
+                        painter = rememberImagePainter(data = payment.imageUrl),
+                        contentDescription = payment.name,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier
+                            .width(23.dp)
+                            .height(23.dp)
+                            .padding(end = 2.dp)
+                    )
+                    Text(text = "${payment.name} - ${payment.details}")
+                    Spacer(modifier = Modifier.weight(1f))
+                    val imageResource = painterResource(id = R.drawable.right_arrow)
+                    Image(
+                        painter = imageResource,
+                        contentDescription = payment.name,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier
+                            .width(23.dp)
+                            .height(23.dp)
+                            .padding(end = 2.dp)
+                    )
+                }
             }
         }
     }
@@ -115,7 +144,7 @@ fun FirstCardContent(mandate: Mandate?) {
             }
         }, fontSize = 12.sp, fontWeight = FontWeight.Light)
         Divider(color = Color.Black, thickness = 1.5.dp)
-        ElevatedCard {
+        ElevatedCard (colors = CardDefaults.elevatedCardColors(Color(0xFFF5F5DC))) {
             Text(color = Color(0xfff2b36f),
                 modifier = Modifier.padding(10.dp),
                 text = buildAnnotatedString {
@@ -138,19 +167,20 @@ fun FirstCardContent(mandate: Mandate?) {
 @Composable
 fun paymentCardContent(
     paymentGateway: PaymentGateway,
-    onClick: (PaymentGateway) -> Unit
+    onClick: (PaymentGateway) -> Unit,
 ) {
     Card(
         modifier = Modifier
+            .width(110.dp)
+            .height(90.dp)
             .clickable { onClick(paymentGateway) }
-            .padding(end = 8.dp)
-            .fillMaxWidth()
+            .padding(5.dp),
     ) {
         Box(contentAlignment = Alignment.Center) {
             Image(
                 painter = rememberImagePainter(data = paymentGateway.imageUrl),
                 contentDescription = paymentGateway.name,
-                contentScale = ContentScale.Crop,
+                contentScale = ContentScale.Fit,
                 modifier = Modifier.fillMaxSize()
             )
         }

--- a/app/src/main/res/drawable/right_arrow.xml
+++ b/app/src/main/res/drawable/right_arrow.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M8.59,16.59L13.17,12 8.59,7.41 10,6l6,6 -6,6 -1.41,-1.41z"/>
+</vector>


### PR DESCRIPTION
In this PR, the following changes have been made:
- The last Card which will show the "Pay using" module is added. 
- Current UI is slightly change to match the required UI.
- JSON file is updated.

Testing:
- The testing is done with local phone: Specification: One Plus Nord 2T, OS - 13
- Video is attached here: [sample_video](https://drive.google.com/drive/folders/1_kwlVCmMMe3tchmkrcM5i0XUSQ3yCRXG?usp=drive_link).

Improvement:
- As time was lapsing, one of the task related to: on clicking the card, the color of the card should be changed is left.
- We can organize it more gracefully by having different viewmodel, and related class for Payment gateway.
- Also, instead of defining text each time, we can have a separate text class with the required text style.